### PR TITLE
Update resource urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install @ingest/ingest-node-sdk
 
 2. Require it in your project:
 ```javascript
-  const IngestSDK = require('ingest-node-sdk')
+  const IngestSDK = require('@ingest/ingest-node-sdk')
 ```
 
 3. Initialize the SDK:

--- a/lib/core/Resource.js
+++ b/lib/core/Resource.js
@@ -21,14 +21,14 @@ class Resource {
     }
 
     this.defaults = {
-      all: '/<%=resource%>',
-      byId: '/<%=resource%>/<%=id%>',
-      thumbnails: '/<%=resource%>/<%=id%>/thumbnails',
-      trash: '/<%=resource%>?filter=trashed',
+      all: '<%=resource%>',
+      byId: '<%=resource%>/<%=id%>',
+      thumbnails: '<%=resource%>/<%=id%>/thumbnails',
+      trash: '<%=resource%>?filter=trashed',
       deleteMethods: {
         'permanent': '?permanent=1'
       },
-      search: '/<%=resource%>?search=<%=input%>',
+      search: '<%=resource%>?search=<%=input%>',
       resource: null
     }
 

--- a/lib/resources/Events.js
+++ b/lib/resources/Events.js
@@ -12,7 +12,7 @@ const Utils = require('../core/Utils')
 class Events extends Resource {
   constructor () {
     const options = {
-      resource: 'events',
+      resource: '/events',
       types: '/<%=resource%>/types'
     }
     super(options)

--- a/lib/resources/Inputs.js
+++ b/lib/resources/Inputs.js
@@ -15,7 +15,7 @@ class Inputs extends Resource {
    */
   constructor () {
     const overrides = {
-      resource: 'encoding/inputs',
+      resource: '/encoding/inputs',
       allWithFilters: '/<%=resource%>?filter=<%=filterChain%>',
       searchWithFilters: '/<%=resource%>?search=<%=input%>&filter=<%=filterChain%>'
     }

--- a/lib/resources/Jobs.js
+++ b/lib/resources/Jobs.js
@@ -15,7 +15,7 @@ class Jobs extends Resource {
    */
   constructor () {
     const options = {
-      resource: 'encoding/jobs',
+      resource: '/encoding/jobs',
       progress: '/<%=resource%>/<%=id%>/progress'
     }
     super(options)

--- a/lib/resources/Livestreams.js
+++ b/lib/resources/Livestreams.js
@@ -15,7 +15,7 @@ class Livestreams extends Resource {
    */
   constructor () {
     const overrides = {
-      resource: 'live',
+      resource: '/live',
       status: '/<%=resource%>/<%=id%>/status',
       deleteMethods: {
         'end': '?end=1'

--- a/lib/resources/Networks.js
+++ b/lib/resources/Networks.js
@@ -15,7 +15,7 @@ class Networks extends Resource {
    */
   constructor () {
     const overrides = {
-      resource: 'networks',
+      resource: '/networks',
       keys: '/<%=resource%>/<%=networkId%>/keys',
       keysById: '/<%=resource%>/<%=networkId%>/keys/<%=keyId%>',
       invite: '/<%=resource%>/<%=networkId%>/invite',

--- a/lib/resources/Profiles.js
+++ b/lib/resources/Profiles.js
@@ -15,7 +15,7 @@ class Profiles extends Resource {
    */
   constructor () {
     const options = {
-      resource: 'encoding/profiles'
+      resource: '/encoding/profiles'
     }
     super(options)
   }

--- a/lib/resources/Roles.js
+++ b/lib/resources/Roles.js
@@ -15,7 +15,7 @@ class Roles extends Resource {
    */
   constructor () {
     const options = {
-      resource: 'roles'
+      resource: '/roles'
     }
     super(options)
   }

--- a/lib/resources/Users.js
+++ b/lib/resources/Users.js
@@ -6,7 +6,7 @@ const Utils = require('../core/Utils')
 class Users extends Resource {
   constructor () {
     const overrides = {
-      resource: 'users',
+      resource: '/users',
       currentUser: '/users/me',
       transfer: '/users/<%=oldId%>/transfer/<%=newId%>',
       updateRoles: '/users/<%=id%>/roles',

--- a/lib/resources/Videos.js
+++ b/lib/resources/Videos.js
@@ -15,7 +15,7 @@ class Videos extends Resource {
    */
   constructor () {
     const overrides = {
-      resource: 'videos',
+      resource: '/videos',
       variants: '/<%=resource%>/<%=id%>/variants',
       publish: '/<%=resource%>/publish',
       thumbnail: '/<%=resource%>/<%=id%>/thumbnail',


### PR DESCRIPTION
`getCurrentUserInfo` ran into a conflict when calling `parseTokens`.

Because `this.config.all` basically resolved to the http://baseapi/ when we run the code 

```javascript
    const url = Utils.parseTokens(this.config.all, {
      resource: this.config.currentUser
    })
```

We were returning back: `https://baseapi//users/me` which was actually causing a 404 to be returned. Simply to avoid this going forward and remain consistent in code. I removed the suffixed `/` on the base resource `all` string and added it to the base inside each resource. This keeps the URL configs inside each of the resources consistent.

I couldn't determine a good way to test this as we don't expose the URL anywhere in the response object returned. That would be the most reliable place to test the validity of the URL rather than feeding mocked data to the parseTokens func, we already test that, what we really need to test is the config params in each of the resources.


*note* also updated README.md to show the proper path to include the SDK.