### PR TITLE
INGEST-3258: On Demand Transcoder changes

### DIFF
--- a/__tests__/lib/resources/Livestreams.spec.js
+++ b/__tests__/lib/resources/Livestreams.spec.js
@@ -64,17 +64,9 @@ describe('Livestreams Tests', () => {
     })
   })
 
-  describe('Livestreams:: delete', () => {
-    it('Should call send request if id, end and callback are all valid', () => {
-      this.resource.delete('id', true, (err, res) => {
-        expect(res).toBeDefined()
-        expect(err).toBeNull()
-        expect(this.resource._sendRequest).toHaveBeenCalled()
-      })
-    })
-
-    it('Should call send request if end param is false', () => {
-      this.resource.delete('id', false, (err, res) => {
+  describe('Livestreams:: end', () => {
+    it('Should call send request if id, streamKey and callback are all valid', () => {
+      this.resource.end('id', 'streamkey', (err, res) => {
         expect(res).toBeDefined()
         expect(err).toBeNull()
         expect(this.resource._sendRequest).toHaveBeenCalled()
@@ -82,7 +74,15 @@ describe('Livestreams Tests', () => {
     })
 
     it('Should call handleInputError if id is not a string', () => {
-      this.resource.delete({}, false, (err, res) => {
+      this.resource.end({}, 'streamkey', (err, res) => {
+        expect(err).toBeDefined()
+        expect(res).toBeNull()
+        expect(this.resource._handleInputError).toHaveBeenCalled()
+      })
+    })
+
+    it('Should call handleInputError if streamkey is not a string', () => {
+      this.resource.end('id', {}, (err, res) => {
         expect(err).toBeDefined()
         expect(res).toBeNull()
         expect(this.resource._handleInputError).toHaveBeenCalled()

--- a/lib/resources/Livestreams.js
+++ b/lib/resources/Livestreams.js
@@ -17,10 +17,9 @@ class Livestreams extends Resource {
     const overrides = {
       resource: '/live',
       status: '/<%=resource%>/<%=id%>/status',
-      deleteMethods: {
-        'end': '?end=1'
-      }
+      end: '/<%=resource%>/<%=id%>/stop'
     }
+
     super(overrides)
   }
 
@@ -87,34 +86,32 @@ class Livestreams extends Resource {
   }
 
   /**
-   * Delete/End a single livestream
+   * Ends a livestream
    *
-   * @param  {string}   id       - Livestream id.
-   * @param  {boolean}  end      - A flag to end the stream instead of remove it
-   * @param  {Function} callback - (optional) Called when the request is complete.
+   * @param {string} id        - The id of the livestream to end
+   * @param {string} streamKey - The streamKey for the livestream you wish to end
    *
-   * @return {Function|Promise}  - Calls a callback if one was provided, otherwise it returns a promise.
+   * @return {promise} A promise which resolves when the request is complete.
    */
-  delete (id, end, callback) {
+  end (id, streamKey, callback) {
     let options, url
 
-    if (typeof id !== 'string') {
-      const error = new Error('IngestSDK Livestream.delete requires a valid id passed as a string.')
+    if (typeof id !== 'string' || typeof streamKey !== 'string') {
+      const error = new Error('IngestSDK Livestream.end requires a valid id and stream key passed as a string.')
       return this._handleInputError(error, callback)
     }
 
-    url = Utils.parseTokens(this.config.byId, {
+    url = Utils.parseTokens(this.config.end, {
       resource: this.config.resource,
       id: id
     })
 
-    if (end) {
-      url += this.config.deleteMethods.end
-    }
-
     options = {
-      url,
-      method: 'DELETE'
+      url: url,
+      method: 'POST',
+      data: {
+        stream_key: streamKey
+      }
     }
 
     return this._sendRequest(options, callback)


### PR DESCRIPTION
Due to the new On Demand Transcoder support we needed to change the end livestream endpoint. The delete and permanent delete endpoints now pull from the base class instead